### PR TITLE
Limit cases to 100

### DIFF
--- a/src/edit/advanced.html
+++ b/src/edit/advanced.html
@@ -27,7 +27,7 @@
     <!-- <script type="text/javascript" src="js/canadamap.js"></script> -->
     <script type="text/javascript" src="js/drawChart.js"></script>
     <!-- <script type="text/javascript" src="js/state.js"></script> -->
-    <script type="text/javascript" src="js/advanced.js"></script>
+    <script type="text/javascript" src="js/advanced.js?v=1.1"></script>
     <script type="text/javascript" src="js/config.js"></script>
 
 
@@ -112,7 +112,7 @@
                 </div>
 
                 <div class="card mb-4">
-                    <div class="card-header"><i class="fas fa-table mr-1"></i>Individual Cases</div>
+                    <div class="card-header"><i class="fas fa-table mr-1"></i>Latest 100 Cases</div>
                     <div class="card-body">
                         <div class="table-responsive" id="individualCaseTableDiv">
                             <table class="table table-bordered" id="individualCaseTable" width="100%" cellspacing="0">
@@ -146,6 +146,7 @@
                                 </tbody>
                             </table>
                         </div>
+                        <button onClick="return false;" class="btn btn-secondary mt-4" disabled title="Coming soon">See All Cases</button>
                     </div>
                 </div>
             </div>

--- a/src/edit/index.html
+++ b/src/edit/index.html
@@ -162,7 +162,7 @@
                 </div>
 
                 <div class="card mb-4">
-                    <div class="card-header"><i class="fas fa-table mr-1"></i>Individual Cases</div>
+                    <div class="card-header"><i class="fas fa-table mr-1"></i>Latest 100 Cases</div>
                     <div class="card-body">
                         <div class="table-responsive">
                             <table class="table table-bordered" id="individualCaseTable" width="100%" cellspacing="0">
@@ -196,6 +196,7 @@
                                 </tbody>
                             </table>
                         </div>
+                        <button onClick="return false;" class="btn btn-secondary mt-4" disabled title="Coming soon">See All Cases</button>
                     </div>
                 </div>
 

--- a/src/edit/js/advanced.js
+++ b/src/edit/js/advanced.js
@@ -37,10 +37,10 @@ function getProvinceData(province) {
         var cases = 0;
         var deaths = 0;
         if ("cases" in res["data"])
-            cases = res["data"]["cases"].length;
+            cases = res["data"]["total_cases"];
 
         if ("deaths" in res["data"])
-            deaths = res["data"]["deaths"].length;
+            deaths = res["data"]["total_deaths"];
 
         $('#provinceTotalCases')[0].innerHTML = "Total Cases: " + cases;
         $('#provinceTotalDeaths')[0].innerHTML = "Total Deaths: " + deaths;


### PR DESCRIPTION
#### src/edit/advanced.html
Label to say "Latest 100", disabled button for all cases, and versioning `advanced.js` to break cache.

#### src/edit/api/entities/cases.php
Set default `LIMIT` to 100 and prepared `OFFSET` support for future for `individualCases` and `getProvinceData`; modified the province query to calculate `FOUND_ROWS()`.

#### src/edit/index.html
Label to say "Latest 100" and disabled button for all cases.

#### src/edit/js/advanced.js
Modified attributes to pull for total province cases/fatalities.